### PR TITLE
Fix cell removals

### DIFF
--- a/Load Data.ipynb
+++ b/Load Data.ipynb
@@ -149,10 +149,8 @@
     "# remove noisy channels from batch3\n",
     "del batch3['b3c37']\n",
     "del batch3['b3c2']\n",
-    "del batch3['b3c23']\n",
-    "del batch3['b3c32']\n",
-    "del batch3['b3c38']\n",
-    "del batch3['b3c39']"
+    "del batch3['b3c39']\n",
+    "del batch3['b3c40']"
    ]
   },
   {

--- a/Load Data.ipynb
+++ b/Load Data.ipynb
@@ -149,8 +149,10 @@
     "# remove noisy channels from batch3\n",
     "del batch3['b3c37']\n",
     "del batch3['b3c2']\n",
-    "del batch3['b3c39']\n",
-    "del batch3['b3c40']"
+    "del batch3['b3c23']\n",
+    "del batch3['b3c32']\n",
+    "del batch3['b3c42']\n",
+    "del batch3['b3c43']"
    ]
   },
   {


### PR DESCRIPTION
This PR address an error in the python data loader. In MatLab, deleted entries change the index of the cells so that the deletion is dependent on the order of the deletion if the index is higher.

From Joachim Schaeffer:
Both python and Matlab start with loading the batch3. 
“LoadData.m" loads from "2018-04-12_batchdata_updated_struct_errorcorrect.mat"
In python "BuildPkl_Batch3.ipynb" loads the data from the “.mat" file and then saves it as “.pkl".
The “.pkl" is loaded via "Load Data.ipynb”.

Now, we have 46 cells in MATLAB with indices starting from 1 to 46. 
In python, we have 46 cells, with keys b3c0 - b3c45. 
I checked their cycle life and they correspond 1:1 with b3c0 <—> index 1, b3c1 <—> index 2, … b3c45 <—> index 46,

Line 50 Matlab: 
Cell with index 38 is removed. Corresponding python dict: b3c37. 
Now the Matlab indices go from 1-45, with the old indices 39-46 now being 38-45. 

Line 58 Matlab: 
rind = [24,33] corresponding to b3c23 and b3c32 are removed at the same time. These batteries didn’t finish in batch3, thus no cycle life information is available. 
Now the Matlab indices are shifted by 0, -1, -2, and -3, depending on their location in the array. 

Line 62 Matlab: 
nind = [3, 40,41] corresponding to b3c2 (no Matlab index shift, but Matlab starts with 1, python with 0), b3c42, b3c43 (back shifting the index by +3, then -1 to compensate 0/1 index difference) 
